### PR TITLE
add an image of the ttl graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Domain ontology for atomistic and electronic modelling
 ======================================================
 An EMMO-based domain ontology for atomistic and electronic modelling.
-
+![image](https://user-images.githubusercontent.com/45469701/145525645-4085c0de-efae-4975-811c-50730bde5ae2.png) <--- generated using https://www.ldf.fi/service/rdf-grapher --->
 
 Status
 ------


### PR DESCRIPTION
When I looked through these initially, there was enough of a blockade to getting a visualization that I ended up not coming back to it for a while. An image (even if not meant to be used directly), might help people for the various EMMO repositories, especially if they're not familiar with TLL files or it's their first time hearing about materials science entologies.

Neat work.